### PR TITLE
1.0.3: fix: add descriptions, keys and "in" support on the instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aurelia-class-enhancements",
   "description": "Enhance your Aurelia's classes with high order functionality",
   "homepage": "https://homer0.github.io/aurelia-class-enhancements/",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": "homer0/aurelia-class-enhancements",
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -153,6 +153,10 @@ const enhanceInstance = (ProxyClass, target, enhancement) => new Proxy(target, {
 
     return result;
   },
+  has: (targetCls, name) => (
+    name in targetCls ||
+    name in enhancement
+  ),
 });
 /**
  * Creates a proxy from a target class declaration in order to:

--- a/src/index.js
+++ b/src/index.js
@@ -165,6 +165,10 @@ const enhanceInstance = (ProxyClass, target, enhancement) => new Proxy(target, {
 
     return result;
   },
+  ownKeys: (targetCls) => [...new Set([
+    ...Reflect.ownKeys(targetCls),
+    ...Reflect.ownKeys(enhancement),
+  ])],
 });
 /**
  * Creates a proxy from a target class declaration in order to:

--- a/src/index.js
+++ b/src/index.js
@@ -157,6 +157,14 @@ const enhanceInstance = (ProxyClass, target, enhancement) => new Proxy(target, {
     name in targetCls ||
     name in enhancement
   ),
+  getOwnPropertyDescriptor: (targetCls, name) => {
+    let result = Object.getOwnPropertyDescriptor(enhancement, name);
+    if (typeof result === 'undefined') {
+      result = Object.getOwnPropertyDescriptor(targetCls, name);
+    }
+
+    return result;
+  },
 });
 /**
  * Creates a proxy from a target class declaration in order to:

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -429,4 +429,44 @@ describe('aurelia-class-enhancements', () => {
     // Then
     expect(result).toBe(Base.staticProp);
   });
+
+  it('should have descriptions for both, the enhancement and the target, properties', () => {
+    // Given
+    const baseProperty = 'baseId';
+    const basePropertyValue = 'base';
+    const enhancedProperty = 'id';
+    const enhancedPropertyBaseValue = 'base';
+    class Base {
+      constructor() {
+        this[baseProperty] = basePropertyValue;
+        this[enhancedProperty] = enhancedPropertyBaseValue;
+      }
+    }
+    const enhancedPropertyValue = 'enhanced';
+    class Enhancement {
+      constructor() {
+        this[enhancedProperty] = enhancedPropertyValue;
+      }
+    }
+    let sut = null;
+    let basePropertyDescription = null;
+    let enhancedPropertyDescription = null;
+    // When
+    sut = new (enhance(Enhancement)(Base))();
+    basePropertyDescription = Object.getOwnPropertyDescriptor(sut, baseProperty);
+    enhancedPropertyDescription = Object.getOwnPropertyDescriptor(sut, enhancedProperty);
+    // Then
+    expect(basePropertyDescription).toEqual({
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: basePropertyValue,
+    });
+    expect(enhancedPropertyDescription).toEqual({
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: enhancedPropertyValue,
+    });
+  });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -342,6 +342,7 @@ describe('aurelia-class-enhancements', () => {
     sut.attached(arg);
     // Then
     expect(sut).toBeInstanceOf(Base);
+    expect('attached' in sut).toBeTrue();
     expect(enhanceAttached).toHaveBeenCalledTimes(1);
     expect(enhanceAttached).toHaveBeenCalledWith(arg);
   });
@@ -384,6 +385,7 @@ describe('aurelia-class-enhancements', () => {
     sut.attached(arg);
     // Then
     expect(sut).toBeInstanceOf(Base);
+    expect('attached' in sut).toBeTrue();
     expect(baseAttached).toHaveBeenCalledTimes(1);
     expect(baseAttached).toHaveBeenCalledWith(arg);
   });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -469,4 +469,31 @@ describe('aurelia-class-enhancements', () => {
       value: enhancedPropertyValue,
     });
   });
+
+  it('should have merge both keys, from the target and the enhancement, for Object.keys', () => {
+    // Given
+    const baseProperty = 'baseId';
+    const enhancedProperty = 'id';
+    class Base {
+      constructor() {
+        this[baseProperty] = null;
+        this[enhancedProperty] = null;
+      }
+    }
+    class Enhancement {
+      constructor() {
+        this[enhancedProperty] = null;
+      }
+    }
+    let sut = null;
+    let result = null;
+    // When
+    sut = new (enhance(Enhancement)(Base))();
+    result = Object.keys(sut);
+    // Then
+    expect(result).toEqual([
+      baseProperty,
+      enhancedProperty,
+    ]);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

More random issues with the Aurelia router; this PR add supports for:

- `in` operator: When called `'property' in class`, the proxy will now check on both the target and the enhancement.
- descriptions: Like on #1; this adds support for `getOwnPropertyDescriptor`, but this time is for the instance.
- keys: When an enhanced class is called on `Object.keys`, it now returns the keys from both, the enhancement and the target.

### How should it be tested manually?

Create an enhanced class and try calling `in`, `getOwnPropertyDescriptor` and `Object.keys`, or...

```bash
yarn test
# or
npm test
```